### PR TITLE
fix crash/ub

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -81,7 +81,8 @@ void TitleThread()
 std::thread Title(TitleThread);
 int main()
 {
-
+	Title.detach();
+	
 	HANDLE hInput;
 	DWORD prev_mode;
 	hInput = GetStdHandle(STD_INPUT_HANDLE);


### PR DESCRIPTION
Fix crash & undefined behavior due to forgetting to join thread in the end. Since we don't wanna wait infinitely we just detach the thread that randomizes the title.